### PR TITLE
Add vectorized calls for u[l](x) and v[l](y)

### DIFF
--- a/python/irbasis.py
+++ b/python/irbasis.py
@@ -150,7 +150,7 @@ class _PiecewiseLegendrePoly:
     def __call__(self, x, l=Ellipsis):
         """Evaluate polynomial at position x"""
         i, xtilde = self._split(x)
-        res = legval(xtilde, self.data[:,i,l], tensor=True)
+        res = legval(xtilde, self.data[:,i,l], tensor=False)
         res *= self._norm[i]
         return res
 
@@ -264,14 +264,14 @@ class basis(object):
         """
         return self._dim
 
-    def sl(self, l):
+    def sl(self, l=None):
         """
         Return the singular value for the l-th basis function
 
         Parameters
         ----------
-        l : int
-            index of the singular values/basis functions
+        l : int, int-like array or None
+            index of the singular values/basis functions. If None, return all.
 
         Returns
         sl : float
@@ -279,6 +279,8 @@ class basis(object):
         -------
 
         """
+        if l is None: l = Ellipsis
+
         return self._sl[l]
     
     def ulx(self, l, x):
@@ -287,8 +289,8 @@ class basis(object):
 
         Parameters
         ----------
-        l : int or int-like array
-            index of basis functions
+        l : int, int-like array or None
+            index of basis functions. If None, return array with all l
         x : float or float-like array
             dimensionless parameter x (-1 <= x <= 1)
 
@@ -297,6 +299,7 @@ class basis(object):
         ulx : float
             value of basis function u_l(x)
         """
+        if l is None: l = Ellipsis
         return self._ulx_ppoly(x,l)
 
     def d_ulx(self, l, x, order, section=None):
@@ -305,8 +308,8 @@ class basis(object):
 
         Parameters
         ----------
-        l : int  or int-like array
-            index of basis functions
+        l : int, int-like array or None
+            index of basis functions. If None, return array with all l
         x : float or float-like array
             dimensionless parameter x
         order : int
@@ -320,6 +323,7 @@ class basis(object):
             (higher-order) derivative of u_l(x)
 
         """
+        if l is None: l = Ellipsis
         return self._ulx_ppoly.deriv(order)(x,l)
 
     def vly(self, l, y):
@@ -328,9 +332,9 @@ class basis(object):
 
         Parameters
         ----------
-        l : int
-            index of basis functions
-        y : float
+        l : int, int-like array or None
+            index of basis functions. If None, return array with all l
+        y : float or float-like array
             dimensionless parameter y (-1 <= y <= 1)
 
         Returns
@@ -338,6 +342,7 @@ class basis(object):
         vly : float
             value of basis function v_l(y)
         """
+        if l is None: l = Ellipsis
         return self._vly_ppoly(y,l)
 
     def d_vly(self, l, y, order):
@@ -346,9 +351,9 @@ class basis(object):
 
         Parameters
         ----------
-        l : int
-            index of basis functions
-        y : int
+        l : int, int-like array or None
+            index of basis functions. If None, return array with all l
+        y : float or float-like array
             dimensionless parameter y
         order : int
             order of derivative (>=0). 1 for the first derivative.
@@ -361,6 +366,7 @@ class basis(object):
             (higher-order) derivative of v_l(y)
 
         """
+        if l is None: l = Ellipsis
         return self._vly_ppoly.deriv(order)(y,l)
 
     def compute_unl(self, n):
@@ -399,11 +405,8 @@ class basis(object):
         # Compute tail
         replaced_with_tail = numpy.zeros((num_n, self.dim()), dtype=int)
         deriv_x1 = numpy.zeros((self.dim(), num_deriv), dtype=float)
-
-        all_l = numpy.arange(self.dim())
         for o in range(num_deriv):
-            deriv_x1[:,o] = self.d_ulx(all_l, 1.0, o)
-
+            deriv_x1[:,o] = self.d_ulx(None, 1.0, o)
         unl_tail = _compute_unl_tail(w_vec.astype(float), self._statistics, deriv_x1)
         unl_tail_without_last_two = _compute_unl_tail(w_vec.astype(float), self._statistics, deriv_x1[:, :-2])
         for i in range(len(n)):

--- a/python/setup.py
+++ b/python/setup.py
@@ -14,7 +14,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 setup(
     name='irbasis',
 
-    version='2.0.0',
+    version='2.1.0',
 
     description='Python libraries for irbasis',
 

--- a/test/python/check_ulx_vly.py
+++ b/test/python/check_ulx_vly.py
@@ -49,6 +49,39 @@ class TestMethods(unittest.TestCase):
             d_2nd_differential = abs((d_ulx_ref_np8_2nd - rb_np8.d_ulx(Nl-1, 1.0, 2)) / d_ulx_ref_np8_2nd)
             self.assertLessEqual(d_2nd_differential, 1e-11)
 
+    def test_vectorization(self):
+        for _lambda in [1E+4]:
+            prefix = "basis_f-mp-Lambda" + str(_lambda)
+            rb = ir.basis("../irbasis.h5", prefix)
+
+            # re-vectorized functions
+            revec_ulx = numpy.vectorize(rb.ulx)
+            revec_vly = numpy.vectorize(rb.vly)
+            revec_sl = numpy.vectorize(rb.sl)
+
+            # check that those match:
+            x = numpy.array([-.3, .2, .5])
+            l = numpy.array([1, 3, 10, 15], dtype=int)
+            alll = numpy.arange(rb.dim())
+
+            self.assertTrue(numpy.allclose(revec_sl(l), rb.sl(l)))
+            self.assertTrue(numpy.allclose(revec_sl(alll), rb.sl()))
+
+            self.assertTrue(numpy.allclose(revec_ulx(l[0], x), rb.ulx(l[0], x)))
+            self.assertTrue(numpy.allclose(revec_ulx(l, x[0]), rb.ulx(l, x[0])))
+            self.assertTrue(numpy.allclose(revec_ulx(alll, x[0]),
+                                           rb.ulx(None, x[0])))
+            self.assertTrue(numpy.allclose(revec_ulx(l[:,None], x[None,:]),
+                                           rb.ulx(l[:,None], x[None,:])))
+
+            self.assertTrue(numpy.allclose(revec_vly(l[0], x), rb.vly(l[0], x)))
+            self.assertTrue(numpy.allclose(revec_vly(l, x[0]), rb.vly(l, x[0])))
+            self.assertTrue(numpy.allclose(revec_vly(alll, x[0]),
+                                           rb.vly(None, x[0])))
+            self.assertTrue(numpy.allclose(revec_vly(l[:,None], x[None,:]),
+                                           rb.vly(l[:,None], x[None,:])))
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
 - Add class _PiecewiseLegendrePoly, which represents the way
   the basis fucntion are currently stored in the HDF5 file,
   as well as exposing methods for evaluating these polynomials
   at a vector-valued x.

 - Moved basis.ulx(), basis.vly(), etc. methods to use the
   new infrastructure.