### PR TITLE
Speed up `compute_unl()`, retire mpmath.

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,4 +2,3 @@ numpy
 scipy
 future
 h5py
-mpmath

--- a/python/setup.py
+++ b/python/setup.py
@@ -14,7 +14,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 setup(
     name='irbasis',
 
-    version='2.1.0',
+    version='2.2.0',
 
     description='Python libraries for irbasis',
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -56,7 +56,7 @@ setup(
 
     packages = find_packages(exclude=['contrib', 'docs', 'tests']),
 
-    install_requires=['numpy', 'scipy', 'h5py', 'future', 'mpmath'],
+    install_requires=['numpy', 'scipy', 'h5py', 'future'],
 
     package_data={
         'irbasis': ['irbasis.h5'],

--- a/sample/computing_gl.py
+++ b/sample/computing_gl.py
@@ -28,8 +28,7 @@ def _composite_leggauss(deg, section_edges):
 
 class transformer(object):
     def __init__(self, basis, beta):
-        section_edges_positive_half = numpy.array(basis.section_edges_x)
-        section_edges = numpy.setxor1d(section_edges_positive_half, -section_edges_positive_half)
+        section_edges = numpy.asarray(basis.section_edges_x)
         self._dim = basis.dim()
         self._beta = beta
         self._x, self._w = _composite_leggauss(16, section_edges)

--- a/test/python/check_unl.py
+++ b/test/python/check_unl.py
@@ -63,7 +63,7 @@ class TestMethods(unittest.TestCase):
                 self.assertLessEqual((diff/magnitude).max(), 5e-13)
 
                 # Relative error must be smaller than 1e-12
-                #self.assertLessEqual(numpy.amax(numpy.abs(diff/Giwn_ref)), 1e-12)
+                self.assertLessEqual(numpy.amax(numpy.abs(diff/Giwn_ref)), 5e-13)
 
 
 if __name__ == '__main__':

--- a/test/python/check_unl.py
+++ b/test/python/check_unl.py
@@ -19,7 +19,8 @@ class TestMethods(unittest.TestCase):
         """
         for _lambda in [10.0, 1E+4, 1E+7]:
             for _statistics, pole in product(["f", "b"], [1.0, 0.1]):
-                print(_lambda, _statistics)
+                print("lambda = %d, stat = %s, y = %g" %
+                      (_lambda, repr(_statistics), pole))
                 prefix = "basis_"+_statistics+"-mp-Lambda"+str(_lambda)
                 basis = ir.basis("../irbasis.h5", prefix)
                 dim = basis.dim()
@@ -43,19 +44,26 @@ class TestMethods(unittest.TestCase):
                     return 1/(z - pole)
 
                 # Compute G(iwn) using unl
-                n_plt = numpy.array([-1, 0, 1, 1E+1, 1E+2, 1E+3, 1E+4, 1E+5, 1E+6, 1E+7, 1E+8, 1E+9, 1E+10, 1E+14], dtype=int)
+                n_plt = numpy.array([-1, 0, 1, 1E+1, 1E+2, 1E+3, 1E+4,
+                                     1E+5, 1E+6, 1E+7, 1E+8, 1E+9, 1E+10, 1E+14],
+                                    dtype=int)
                 Uwnl_plt =  numpy.sqrt(beta) * basis.compute_unl(n_plt)
                 Giwn_t = numpy.dot(Uwnl_plt, gl)
 
                 # Compute G(iwn) from analytic expression
                 Giwn_ref = numpy.array([G(n) for n in n_plt])
 
+                magnitude = numpy.abs(Giwn_ref).max()
+                diff = numpy.abs(Giwn_t - Giwn_ref)
+                reldiff = diff/numpy.abs(Giwn_ref)
+
                 # Absolute error must be smaller than 1e-12
-                diff = Giwn_t - Giwn_ref
-                self.assertLessEqual(numpy.amax(numpy.abs(diff)), 1e-12)
+                print ("max. absdiff = %.4g, rel = %.4g" %
+                       (diff.max()/magnitude, reldiff.max()))
+                self.assertLessEqual((diff/magnitude).max(), 5e-13)
 
                 # Relative error must be smaller than 1e-12
-                self.assertLessEqual(numpy.amax(numpy.abs(diff/Giwn_ref)), 1e-12)
+                #self.assertLessEqual(numpy.amax(numpy.abs(diff/Giwn_ref)), 1e-12)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR transitions the computation of `unl`, i.e., the transformation matrix from the IR basis to Matsubara frequencies from a mpmath based approach to a stabilized double precision calculation.

The values agree with the old code to ~ 3 ulp (`6e-16`)  (a naive algorithm is found to have deviations up to ~ 100 ulp, which messes up quantum chemistry calculations).  This slight loss of accuracy allows the code however to be about a factor of 7 faster, and the computation of sampling frequencies is even faster due to a new parameter.

Due to the slight regression in accuracy, I had to relax the unit test somewhat.